### PR TITLE
ci: locking the postgres image version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       STATIC_URL: http://localhost:9000/edm-su-test
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:14-alpine3.17
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: edm_su_test


### PR DESCRIPTION
Fix https://github.com/docker-library/postgres/issues/1076